### PR TITLE
added WET24 and link to messages

### DIFF
--- a/current/fslibs/FarseerCube.py
+++ b/current/fslibs/FarseerCube.py
@@ -849,9 +849,17 @@ If you choose continue, Farseer-NMR will parse out the digits.'.\
         # reads size of target peaklist
         target_ind_init_len = target_pkl.shape[0]
         # expands the target peaklist to the new index
-        target_pkl = \
-            target_pkl.set_index('ResNo').\
-                reindex(ind).reset_index().fillna(fillna)
+        try:
+            target_pkl = \
+                target_pkl.set_index('ResNo').\
+                    reindex(ind).reset_index().fillna(fillna)
+        except ValueError:
+            msg = "Farseer-NMR could not reindex this peaklist. There are \
+several input errors that may occur in this case. Read the Documentation for \
+more details."
+            self.log_r(fsw.gen_wet('ERROR', msg, 24))
+            self.abort()
+        
         # reads length of the expanded peaklist
         target_ind_final_len = target_pkl.shape[0]
         # transfers information of the different columns

--- a/current/fslibs/wet.py
+++ b/current/fslibs/wet.py
@@ -28,6 +28,8 @@ def gen_wet(t, s, n):
 {}
 {}
 {}
+{}
+{}
 
 """.\
         format(
@@ -36,6 +38,11 @@ def gen_wet(t, s, n):
              "\n".join(map(format_msg, textwrap.wrap(s, width=67))),
             line(),
             referwet(n),
+            line(s="please visit"),
+            line(
+                s="github.com/joaomcteixeira/FarSeer-NMR/wiki/WET-List#wet{}".\
+                    format(n)
+                ),
             bottom()
             )
     


### PR DESCRIPTION
This is minor change, nothing to review as functionality was not altered, just to let you know what I have done.

- Now alerts user about duplicated row entries in peaklists
- adds direct hyperlink to WETs Wiki page and to the specific WET message.