### PR TITLE
Checks for misleading characters

### DIFF
--- a/core/fslibs/FarseerCube.py
+++ b/core/fslibs/FarseerCube.py
@@ -1824,7 +1824,8 @@ charaters in Assignment columns in line {}.".format(
             'Height',
             'Volume',
             'Line Width F1 (Hz)',
-            'Line Width F2 (Hz)'
+            'Line Width F2 (Hz)',
+            'Merit'
             ]
         
         for col in cols:


### PR DESCRIPTION
Fix #65 

plus additions.

Now before performing FarseerCube.split_res_info(), scans through all columns for invalid characters
and raises WET if any is found. Warns user where the char is found. Char must be removed manually by user.
Version 2 may handle all this automatically.

p.s. - regex still drive me crazy. Bookmark for future: https://pythex.org/