### PR TITLE
Values Field in peaklist ALLOWED CHARS

### DIFF
--- a/gui/components/ValuesField.py
+++ b/gui/components/ValuesField.py
@@ -21,24 +21,10 @@ You should have received a copy of the GNU General Public License
 along with Farseer-NMR. If not, see <http://www.gnu.org/licenses/>.
 """
 
-DISALLOWED_CHARS = [
-    '.',
-    ':',
-    '"',
-    '/',
-    '\\',
-    '°',
-    "'",
-    '*',
-    '?',
-    '!',
-    ';',
-    "`",
-    "^"
-]
-
+import string
 from PyQt5.QtWidgets import QLineEdit, QMessageBox, QSizePolicy
 
+allowed_chars = string.ascii_letters + string.digits + "_"
 
 class ValueField(QLineEdit):
     """
@@ -63,18 +49,16 @@ class ValueField(QLineEdit):
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
         self.msg = QMessageBox()
         self.msg.setIcon(QMessageBox.Warning)
-        self.msg.setText("Invalid Characters in Condition Name")
+        self.msg.setText("Invalid Characters in Condition Name.")
         self.msg.setInformativeText(
-"""These characters:
- . : " / \ ° ' * ? ! ; ` ^ 
-cannot be used in condition names."""
+"""Only ASCII letters, digits and underscore
+can be used as datapoint names."""
             )
         self.msg.setWindowTitle("Invalid Characters")
         self.msg.setStandardButtons(QMessageBox.Ok)
     
     def updateValuesDict(self, value):
-        
-        if any(substr in DISALLOWED_CHARS for substr in value):
+        if not(all((char in allowed_chars for char in value))):
             self.msg.exec_()
             self.setText(value[:-1])
             return


### PR DESCRIPTION
Changed disallowed chars to allowed chars.
Allows ascii.letter, digits and underscore.
This disallows diacritic marks.

_it was so easy and the other day I simply couldn't figure ti out :-P_