### PR TITLE
astropy was missing in anaconda env spec files

### DIFF
--- a/Documentation/spec-file_32bit.txt
+++ b/Documentation/spec-file_32bit.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: linux-32
 @EXPLICIT
+https://repo.continuum.io/pkgs/free/linux-32/astropy-1.3.2-np112py36_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-32/certifi-2016.2.28-py36_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-32/cycler-0.10.0-py36_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-32/dbus-1.10.20-0.tar.bz2

--- a/Documentation/spec-file_64bit.txt
+++ b/Documentation/spec-file_64bit.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
 @EXPLICIT
+https://repo.continuum.io/pkgs/free/linux-64/astropy-1.3.2-np112py36_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/certifi-2016.2.28-py36_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/cycler-0.10.0-py36_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/dbus-1.10.20-0.tar.bz2


### PR DESCRIPTION
Added astropy in spec-files for env creation
astropy is required for PRE analysis