### PR TITLE
Checks duplicated entries AND solves Sidechain issues

### DIFF
--- a/core/fslibs/FarseerCube.py
+++ b/core/fslibs/FarseerCube.py
@@ -369,13 +369,6 @@ the possible options.'
                         format(filetype)
                     self.log_r(fsw.gen_wet('ERROR', msg, 14))
                     self.abort()
-                
-                # if filetype == '.fasta' and resonance_type == 'Backbone':
-                    # self.check_fasta(
-                        # target[parts[1]][parts[2]][lessparts],
-                        # parts[2],
-                        # p
-                        # )
         
         self.checks_xy_datapoints_coherency(target, filetype)
         
@@ -463,7 +456,6 @@ If you choose continue, Farseer-NMR will parse out the digits.'.\
             )
         logs = '  * {}-{}-{}'.format(self.FASTAstart, FASTA, dd['ResNo'][-1])
         self.log_r(logs)
-        #self.check_fasta(df, FASTApath)
         
         return df
     
@@ -1588,36 +1580,7 @@ Correct the reference residue in the Settings Menu.'.\
             self.abort()
         
         return
-
-    def check_fasta(self, df, yy, fasta_path):
-        """
-        Checks if loaded FASTA file has more residues than the reference
-        experiment.
-        
-        FASTA cannot has less rows than the reference experiment.
-        WET#18
-        
-        Parameters:
-            df (pd.DataFrame): contains the FASTA loaded data in
-                DataFrame format as prepared by .read_FASTA().
-            
-            yy (str): the current YY data point name.
-            
-            fasta_path (srt): the .fasta file path.
-        """
-        
-        if df.shape[0] \
-                < self.allpeaklists[self.zzref][yy][self.xxref].\
-                    shape[0]:
-            msg = \
-'The .fasta file in {} has less residue entries than the protein sequence \
-of the reference experiment [{}][{}][{}]'.\
-                format(fasta_path, self.zzref, yy, self.xxref)
-            self.log_r(fsw.gen_wet('ERROR', msg, 18))
-            self.abort()
-        
-        return
-
+    
     def compare_fastas(self):
         """
         Compares all .fasta files to confirm they have the same size.


### PR DESCRIPTION
Two issues in the same Pull Request, because they were bound to each other.

1. regarding you real case study, now Farseer-NMR checks in the input peaklists if there are duplicated entries, that is, rows with the same assignment information. Outputs a message indicating exactly where are those lines.
     1. it's up to the user to dicide which remove and which keep.
     1. currently Farseer cannot go further than this. You have made interesting suggestions about creating duplicated datasets that we can address in a near future.
1. There was a bug about sidechains analysis when searching for missing residues. This bug was silent because rarely we use sidechains. This is a broke after library updating that happened somewhere in the past.
     1. now sidechain analysis works. Residues are now identified properly.
1. a bit of code cleaning on this.

The 3 tutorials were tested on this branch and worked fine. You example was tested and worked fine, now a lot of complaints regarding duplicated entries ;-) I run also another examples and worked fine.

This is the version that I would like to send for submission.

EOF :-)