### PR TITLE
Improving identification of CCPNMRv2 peaklists

### DIFF
--- a/core/parsing.py
+++ b/core/parsing.py
@@ -90,8 +90,6 @@ def get_peaklist_format(file_path):
             'Vol. Method',
             'Number'
                 ])
-        print(ls)
-        print(set_headers)
         if ls == set_headers:
             fin.close()
             return "CCPN"


### PR DESCRIPTION
Identification was based on ordered columns starting from column `Number`. This is not always the case. Now it considers a `set` of column names instead.