### PR TITLE
Changed defaults in LabelledSpin and DoubleSpin Boxes

### DIFF
--- a/gui/components/LabelledDoubleSpinBox.py
+++ b/gui/components/LabelledDoubleSpinBox.py
@@ -48,9 +48,9 @@ class LabelledDoubleSpinBox(QWidget):
             self, parent,
             text,
             callback=None,
-            minimum=None,
-            maximum=None,
-            step=None,
+            minimum=-100000,
+            maximum=100000,
+            step=0.1,
             unit=None
             ):
         QWidget.__init__(self, parent)

--- a/gui/components/LabelledSpinBox.py
+++ b/gui/components/LabelledSpinBox.py
@@ -44,7 +44,7 @@ class LabelledSpinBox(QWidget):
         .setValue(float)
         .set_callback(function)
         """
-    def __init__(self, parent, text, callback=None, minimum=None, maximum=None, step=None):
+    def __init__(self, parent, text, callback=None, minimum=-100000, maximum=100000, step=1):
         QWidget.__init__(self, parent)
         layout = QHBoxLayout()
         self.setLayout(layout)


### PR DESCRIPTION
Changed defaults for LabelledSpinBox and LabelledDoubleSpinBox.
Defaults from PyQT of minimum=0 and maximum=99 were not suited for Farseer-NMR.