### PR TITLE
v1.2.5

### DIFF
--- a/core/fslibs/parsing_routines/user_defined_2.py
+++ b/core/fslibs/parsing_routines/user_defined_2.py
@@ -81,12 +81,13 @@ def parse_user_peaklist_2(peaklist_file):
             peak = Peak(
                 peak_number=residue_counter,
                 positions=positions,
-                residue_type=ls[2],
+                residue_type=ls[2].title(),
                 residue_number=ls[1],
                 atoms=atom,
                 linewidths=[0, 0],
                 volume=0,
                 height=0,
+                details="None",
                 format_='user_pkl_2'
                 )
             

--- a/core/parsing.py
+++ b/core/parsing.py
@@ -201,7 +201,7 @@ def read_peaklist(peaklist_file):
     
     file_format = get_peaklist_format(peaklist_file)
     
-    print(file_format)
+    print("{} leaded as: {}".format(peaklist_file, file_format))
     
     dict_of_parsing_functs = {
         'ANSIG':fspr.ansig,

--- a/gui/Footer.py
+++ b/gui/Footer.py
@@ -102,7 +102,7 @@ class Footer(QWidget):
         #
         version = '<span style="color: #036D8F; font-size: 6pt; ' \
                   'font-weight: 400; margin-right: 29px; margin-top: 4px;"' \
-                  '>v.1.2.4&nbsp;&nbsp;&nbsp;&nbsp;</span>'
+                  '>v.1.2.5&nbsp;&nbsp;&nbsp;&nbsp;</span>'
         self.versionLabel = QLabel(version, self)
         self.versionLabel.setAlignment(QtCore.Qt.AlignRight)
         #


### PR DESCRIPTION
_Issue raised privately by user._ User peaklist 2 was reading residue type in `CAPS` instead of `Title` type, giving `KeyErrors` when performing calculations.

* Corrects routine to load user peaklist 2
* improves print on reading peaklists
* updates to v.1.2.5