### PR TITLE
v1.2.6

### DIFF
--- a/core/setup_farseer_calculation.py
+++ b/core/setup_farseer_calculation.py
@@ -138,6 +138,11 @@ def create_directory_structure(output_path, variables):
                             fasta_start
                             )
                         )
+                
+                elif peaklist[0].format_ == 'ccpnmrv2':
+                    pklfh = open(peaklist_path, 'r')
+                    fout.writelines(pklfh.readlines())
+                
                 else:
                     write_peaklist_file(fout, peaklist)
 

--- a/gui/Footer.py
+++ b/gui/Footer.py
@@ -102,7 +102,7 @@ class Footer(QWidget):
         #
         version = '<span style="color: #036D8F; font-size: 6pt; ' \
                   'font-weight: 400; margin-right: 29px; margin-top: 4px;"' \
-                  '>v.1.2.5&nbsp;&nbsp;&nbsp;&nbsp;</span>'
+                  '>v.1.2.6&nbsp;&nbsp;&nbsp;&nbsp;</span>'
         self.versionLabel = QLabel(version, self)
         self.versionLabel.setAlignment(QtCore.Qt.AlignRight)
         #


### PR DESCRIPTION
CCPNMv2 peaklists are not parsed to a list of Peak objects, instead a list of one dummy Peak object is created to identify the target peaklist as CCPNMv2 format. A simply copy routine is used when creating the `spectra/` folder if CCPNMv2 format is found.

As in previous versions, CCPNMv2 peaklists require all columns to be identified as such.

* updates to version 1.2.6