### PR TITLE
v1.3.4 - all ASCII in install headers

### DIFF
--- a/install/commons.py
+++ b/install/commons.py
@@ -1,7 +1,7 @@
 """
 Commons fuctions that serve installation and update.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -27,7 +27,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/install/condamanager.py
+++ b/install/condamanager.py
@@ -2,7 +2,7 @@
 """
 Manages Miniconda and ENV installation.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -10,7 +10,6 @@ AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
 Visit the original Tree-of-Life project at:
 
 https://github.com/joaomcteixeira/Tree-of-Life
-
 
 Find Farseer-NMR project at:
 - J. BioMol NMR Publication:
@@ -28,7 +27,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/install/executables.py
+++ b/install/executables.py
@@ -1,7 +1,7 @@
 """
 Defines Farseer-NMR Executables
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -9,7 +9,6 @@ AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
 Visit the original Tree-of-Life project at:
 
 https://github.com/joaomcteixeira/Tree-of-Life
-
 
 Find Farseer-NMR project at:
 - J. BioMol NMR Publication:
@@ -27,7 +26,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/install/logger.py
+++ b/install/logger.py
@@ -2,7 +2,7 @@
 """
 Logger module.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -10,7 +10,6 @@ AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
 Visit the original Tree-of-Life project at:
 
 https://github.com/joaomcteixeira/Tree-of-Life
-
 
 Find Farseer-NMR project at:
 - J. BioMol NMR Publication:
@@ -28,7 +27,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/install/messages.py
+++ b/install/messages.py
@@ -1,7 +1,7 @@
 """
 Informative messages for the installation and update processes.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -9,7 +9,6 @@ AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
 Visit the original Tree-of-Life project at:
 
 https://github.com/joaomcteixeira/Tree-of-Life
-
 
 Find Farseer-NMR project at:
 - J. BioMol NMR Publication:
@@ -27,7 +26,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -332,20 +331,20 @@ banner = r"""
                                                                         
                                                                         
                                                                         
-______           _____                            _   _ ___  _________  
-|  ___|         /  ___|                          | \ | ||  \/  || ___ \ 
-| |_  __ _  _ __\ `--.   ___   ___  _ __  ______ |  \| || .  . || |_/ / 
-|  _|/ _` || '__|`--. \ / _ \ / _ \| '__||______|| . ` || |\/| ||    /  
-| | | (_| || |  /\__/ /|  __/|  __/| |           | |\  || |  | || |\ \  
-\_|  \__,_||_|  \____/  \___| \___||_|           \_| \_/\_|  |_/\_| \_| 
+______                                           _   _ ___  _________   
+|  ___|                                         | \ | ||  \/  || ___ \  
+| |_  __ _  _ __  ___   ___   ___  _ __  ______ |  \| || .  . || |_/ /  
+|  _|/ _` || '__|/ __| / _ \ / _ \| '__||______|| . ` || |\/| ||    /   
+| | | (_| || |   \__ \|  __/|  __/| |           | |\  || |  | || |\ \   
+\_|  \__,_||_|   |___/ \___| \___||_|           \_| \_/\_|  |_/\_| \_|  
                                                                         
                                                                         
-        __      _____    _____                                          
-       /  |    |____ |  |____ |                                         
-__   __`| |        / /      / /                                         
-\ \ / / | |        \ \      \ \                                         
- \ V / _| |_ _ .___/ /_ .___/ /                                         
-  \_/  \___/(_)\____/(_)\____/                                          
+        __      _____     ___                                           
+       /  |    |____ |   /   |                                          
+__   __`| |        / /  / /| |                                          
+\ \ / / | |        \ \ / /_| |                                          
+ \ V / _| |_ _ .___/ /_\___  |                                          
+  \_/  \___/(_)\____/(_)   |_/                                          
                                                                         
                                                                         
                                                                         

--- a/install/system.py
+++ b/install/system.py
@@ -2,7 +2,7 @@
 MANAGES SYSTEM INFORMATION AND OTHER NECESSARY PARAMETERS
     FOR INSTALLATION AND UPDATE.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -10,7 +10,6 @@ AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
 Visit the original Tree-of-Life project at:
 
 https://github.com/joaomcteixeira/Tree-of-Life
-
 
 Find Farseer-NMR project at:
 - J. BioMol NMR Publication:
@@ -28,7 +27,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -49,7 +48,7 @@ import os
 
 # configure accordingly to the host project
 software_name = "Farseer-NMR"
-software_version = (1, 3, 3)  # v1.0.0
+software_version = (1, 3, 4)  # v1.0.0
 min_space_allowed = 3  # min GB required to install your software
 installation_log_name = "install.log"
 update_log_name = "update.log"

--- a/install/updater.py
+++ b/install/updater.py
@@ -1,7 +1,7 @@
 """
 Manages software updates.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -27,7 +27,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/install_farseernmr.py
+++ b/install_farseernmr.py
@@ -1,7 +1,7 @@
 """
 Farseer-NMR installer.
 
-Copyright © 2017-2019 Farseer-NMR Project
+2017-2019 Farseer-NMR Project.
 
 THIS FILE WAS ADAPTED FROM TREE-OF-LIFE PROJECT (version 1.0.1 - LGPLv3)
 AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
@@ -9,7 +9,6 @@ AND MODIFIED ACCORDINGLY TO THE NEEDS OF THE FARSEER-NMR PROJECT.
 Visit the original Tree-of-Life project at:
 
 https://github.com/joaomcteixeira/Tree-of-Life
-
 
 Find Farseer-NMR project at:
 - J. BioMol NMR Publication:
@@ -27,7 +26,7 @@ Find Farseer-NMR project at:
 THIS FILE IS PART OF THE FARSEER-NMR PROJECT.
 
 Contributors to this file:
-- João M.C. Teixeira (https://github.com/joaomcteixeira)
+- Joao M.C. Teixeira (https://github.com/joaomcteixeira)
 
 Farseer-NMR is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Headers in installation scripts were problematic when using Python2 because of the non-ASCII characters.

Headers corrected to all-ASCII characters.
